### PR TITLE
Update to UE >= 5.5

### DIFF
--- a/EasyKafka.uplugin
+++ b/EasyKafka.uplugin
@@ -22,14 +22,12 @@
 			"PlatformAllowList": [
 				"Win64",
 				"Linux",
-				"LinuxArm64",
-				"HoloLens"
+				"LinuxArm64"
 			],
 			"WhitelistPlatforms": [
 				"Win64",
 				"Linux",
-				"LinuxAArch64",
-				"HoloLens"
+				"LinuxAArch64"
 			]
 		},
 		{
@@ -39,14 +37,12 @@
 			"PlatformAllowList": [
 				"Win64",
 				"Linux",
-				"LinuxArm64",
-				"HoloLens"
+				"LinuxArm64"
 			],
 			"WhitelistPlatforms": [
 				"Win64",
 				"Linux",
-				"LinuxAArch64",
-				"HoloLens"
+				"LinuxAArch64"
 			]
 		},
 		{
@@ -56,14 +52,12 @@
 			"PlatformAllowList": [
 				"Win64",
 				"Linux",
-				"LinuxArm64",
-				"HoloLens"
+				"LinuxArm64"
 			],
 			"WhitelistPlatforms": [
 				"Win64",
 				"Linux",
-				"LinuxAArch64",
-				"HoloLens"
+				"LinuxAArch64"
 			]
 		},
 		{
@@ -73,27 +67,15 @@
 			"PlatformAllowList": [
 				"Win64",
 				"Linux",
-				"LinuxArm64",
-				"HoloLens"
+				"LinuxArm64"
 			],
 			"WhitelistPlatforms": [
 				"Win64",
 				"Linux",
-				"LinuxAArch64",
-				"HoloLens"
+				"LinuxAArch64"
 			]
 		}
 	],
 	"Plugins": [
-		{
-			"Name": "OpenSSLens",
-			"Enabled": true,
-			"PlatformAllowList": [
-				"HoloLens"
-			],
-			"WhitelistPlatforms": [
-				"HoloLens"
-			]
-		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ EasyKafka is a Kafka/Redpanda client sub-system for unreal engine. It supports p
 Link the plugin modules to your project through `<YourModule>.build.cs`:
 
 ```cs
-CppStandard = CppStandardVersion.Cpp17;//avoid using boost
 if(Target.Platform == UnrealTargetPlatform.HoloLens || Target.Platform == UnrealTargetPlatform.Win64)
 	bUseRTTI = true;
 

--- a/Source/EasyKafka/EasyKafka.Build.cs
+++ b/Source/EasyKafka/EasyKafka.Build.cs
@@ -9,7 +9,6 @@ public class EasyKafka : ModuleRules
 	public EasyKafka(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		CppStandard = CppStandardVersion.Cpp17;
 
 		PublicIncludePaths.AddRange(
 			new string[] {

--- a/Source/EasyKafka/EasyKafka.Build.cs
+++ b/Source/EasyKafka/EasyKafka.Build.cs
@@ -49,8 +49,8 @@ public class EasyKafka : ModuleRules
 			}
 			);
 		bEnableExceptions = true;
-
-		if(Target.Platform == UnrealTargetPlatform.HoloLens || Target.Platform == UnrealTargetPlatform.Win64)
+		
+		if(Target.Platform == UnrealTargetPlatform.Win64)
 			bUseRTTI = true;//Avoid using RTTI on limux
     }
 }

--- a/Source/KafkaAdmin/KafkaAdmin.Build.cs
+++ b/Source/KafkaAdmin/KafkaAdmin.Build.cs
@@ -9,7 +9,6 @@ public class KafkaAdmin : ModuleRules
 	public KafkaAdmin(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		CppStandard = CppStandardVersion.Cpp17;
         PublicSystemIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 
         PublicIncludePaths.AddRange(

--- a/Source/KafkaConsumer/KafkaConsumer.Build.cs
+++ b/Source/KafkaConsumer/KafkaConsumer.Build.cs
@@ -45,7 +45,7 @@ public class KafkaConsumer : ModuleRules
 			);
 		bEnableExceptions = true;
 
-        if (Target.Platform == UnrealTargetPlatform.HoloLens || Target.Platform == UnrealTargetPlatform.Win64)
+        if (Target.Platform == UnrealTargetPlatform.Win64)
             bUseRTTI = true;//Avoid using RTTI on limux
     }
 }

--- a/Source/KafkaConsumer/KafkaConsumer.Build.cs
+++ b/Source/KafkaConsumer/KafkaConsumer.Build.cs
@@ -8,7 +8,6 @@ public class KafkaConsumer : ModuleRules
 	public KafkaConsumer(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		CppStandard = CppStandardVersion.Cpp17;
         PublicSystemIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 
         PublicIncludePaths.AddRange(

--- a/Source/KafkaProducer/KafkaProducer.Build.cs
+++ b/Source/KafkaProducer/KafkaProducer.Build.cs
@@ -9,7 +9,6 @@ public class KafkaProducer : ModuleRules
 	public KafkaProducer(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
-		CppStandard = CppStandardVersion.Cpp17;
         PublicSystemIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 
         PublicIncludePaths.AddRange(

--- a/Source/ThirdParty/KafkaLib/KafkaLib.Build.cs
+++ b/Source/ThirdParty/KafkaLib/KafkaLib.Build.cs
@@ -33,26 +33,6 @@ using System.IO;
             );
 
         }
-        else if (Target.Platform == UnrealTargetPlatform.HoloLens)
-        {
-            string LibPath = Path.Combine(ModuleDirectory, "lib/WinArm64");
-            PublicAdditionalLibraries.Add(Path.Combine(LibPath, "rdkafka.lib"));
-            PublicAdditionalLibraries.Add(Path.Combine(LibPath, "rdkafka++.lib"));
-            /*
-			 Windows Kits libs
-			 */
-            PublicAdditionalLibraries.Add(Path.Combine(Target.WindowsPlatform.WindowsSdkDir, "Lib", Target.WindowsPlatform.WindowsSdkVersion, "um/arm64", "kernel32.Lib"));
-            PublicAdditionalLibraries.Add(Path.Combine(Target.WindowsPlatform.WindowsSdkDir, "Lib", Target.WindowsPlatform.WindowsSdkVersion, "um/arm64", "Secur32.Lib"));
-
-            PublicDependencyModuleNames.AddRange(
-            new string[]
-            {
-                "zlib",
-                "OpenSSLens"//OpenSSL libs for WinArm64 https://github.com/sha3sha3/UE-OpenSSL-Hololens.git
-            }
-            );
-
-        }
         else if (Target.Platform == UnrealTargetPlatform.Linux)
 		{
             string LibPath = Path.Combine(ModuleDirectory, "lib/Linux64");


### PR DESCRIPTION
https://forums.unrealengine.com/t/will-hololens-still-be-supported-in-ue5-3/1180763/8
HoloLens is not a valid value for `UnrealTargetPlatform` enum on UE >= 5.3, and makes the plugin fail the build.

https://dev.epicgames.com/documentation/en-us/unreal-engine/epic-cplusplus-coding-standard-for-unreal-engine?application_version=5.5
C++20 is the minimum version since UE >= 5.5